### PR TITLE
Fix noexcept and constraints on value_or() and error_or()

### DIFF
--- a/include/zeus/expected.hpp
+++ b/include/zeus/expected.hpp
@@ -114,6 +114,9 @@ inline constexpr bool is_copy_assignable_or_void_v = is_void_or_v<T, std::is_cop
 template<class T>
 inline constexpr bool is_move_assignable_or_void_v = is_void_or_v<T, std::is_move_assignable<T>>;
 
+template<class From, class To>
+inline constexpr bool is_nothrow_convertible_v = noexcept(static_cast<To>(std::declval<From>()));
+
 } // namespace expected_detail
 
 template<class E>
@@ -1681,9 +1684,7 @@ public:
 
     template<class U>
     constexpr T value_or(U &&v) const & //
-#if __cplusplus >= 202'002L             // doesn't compile with C++17 with MSVC, may be a compiler bug
-        noexcept(std::is_nothrow_copy_constructible_v<T> && std::is_nothrow_convertible_v<U, T>)
-#endif
+        noexcept(std::is_nothrow_copy_constructible_v<T> && expected_detail::is_nothrow_convertible_v<U, T>)
     {
         static_assert(std::is_copy_constructible_v<T>, "T must be copy-constructible");
         static_assert(std::is_convertible_v<U, T>, "is_convertible_v<U, T> must be true");
@@ -1698,9 +1699,7 @@ public:
     }
     template<class U>
     constexpr T value_or(U &&v) && //
-#if __cplusplus >= 202'002L        // doesn't compile with C++17 with MSVC, may be a compiler bug
-        noexcept(std::is_nothrow_copy_constructible_v<T> && std::is_nothrow_convertible_v<U, T>)
-#endif
+        noexcept(std::is_nothrow_move_constructible_v<T> && expected_detail::is_nothrow_convertible_v<U, T>)
     {
         static_assert(std::is_move_constructible_v<T>, "T must be move-constructible");
         static_assert(std::is_convertible_v<U, T>, "is_convertible_v<U, T> must be true");
@@ -1716,9 +1715,7 @@ public:
 
     template<class G = E>
     constexpr E error_or(G &&v) const & //
-#if __cplusplus >= 202'002L             // doesn't compile with C++17 with MSVC, may be a compiler bug
-        noexcept(std::is_nothrow_copy_constructible_v<E> && std::is_nothrow_convertible_v<G, E>)
-#endif
+        noexcept(std::is_nothrow_copy_constructible_v<E> && expected_detail::is_nothrow_convertible_v<G, E>)
     {
         static_assert(std::is_copy_constructible_v<E>, "E must be copy-constructible");
         static_assert(std::is_convertible_v<G, E>, "is_convertible_v<G, E> must be true");
@@ -1733,9 +1730,7 @@ public:
     }
     template<class G = E>
     constexpr E error_or(G &&v) && //
-#if __cplusplus >= 202'002L        // doesn't compile with C++17 with MSVC, may be a compiler bug
-        noexcept(std::is_nothrow_copy_constructible_v<E> && std::is_nothrow_convertible_v<G, E>)
-#endif
+        noexcept(std::is_nothrow_move_constructible_v<E> && expected_detail::is_nothrow_convertible_v<G, E>)
     {
         static_assert(std::is_move_constructible_v<E>, "E must be move-constructible");
         static_assert(std::is_convertible_v<G, E>, "is_convertible_v<G, E> must be true");
@@ -2407,9 +2402,7 @@ public:
 
     template<class G = E>
     constexpr E error_or(G &&v) const & //
-#if __cplusplus >= 202'002L             // doesn't compile with C++17 with MSVC, may be a compiler bug
-        noexcept(std::is_nothrow_copy_constructible_v<E> && std::is_nothrow_convertible_v<G, E>)
-#endif
+        noexcept(std::is_nothrow_copy_constructible_v<E> && expected_detail::is_nothrow_convertible_v<G, E>)
     {
         static_assert(std::is_copy_constructible_v<E>, "E must be copy-constructible");
         static_assert(std::is_convertible_v<G, E>, "is_convertible_v<G, E> must be true");
@@ -2424,9 +2417,7 @@ public:
     }
     template<class G = E>
     constexpr E error_or(G &&v) && //
-#if __cplusplus >= 202'002L        // doesn't compile with C++17 with MSVC, may be a compiler bug
-        noexcept(std::is_nothrow_copy_constructible_v<E> && std::is_nothrow_convertible_v<G, E>)
-#endif
+        noexcept(std::is_nothrow_move_constructible_v<E> && expected_detail::is_nothrow_convertible_v<G, E>)
     {
         static_assert(std::is_move_constructible_v<E>, "E must be move-constructible");
         static_assert(std::is_convertible_v<G, E>, "is_convertible_v<G, E> must be true");

--- a/include/zeus/expected.hpp
+++ b/include/zeus/expected.hpp
@@ -1702,7 +1702,7 @@ public:
         noexcept(std::is_nothrow_copy_constructible_v<T> && std::is_nothrow_convertible_v<U, T>)
 #endif
     {
-        static_assert(std::is_copy_constructible_v<T>, "T must be copy-constructible");
+        static_assert(std::is_move_constructible_v<T>, "T must be move-constructible");
         static_assert(std::is_convertible_v<U, T>, "is_convertible_v<U, T> must be true");
         if (this->m_has_val)
         {
@@ -1737,7 +1737,7 @@ public:
         noexcept(std::is_nothrow_copy_constructible_v<E> && std::is_nothrow_convertible_v<G, E>)
 #endif
     {
-        static_assert(std::is_copy_constructible_v<E>, "E must be copy-constructible");
+        static_assert(std::is_move_constructible_v<E>, "E must be move-constructible");
         static_assert(std::is_convertible_v<G, E>, "is_convertible_v<G, E> must be true");
         if (this->m_has_val)
         {
@@ -2428,7 +2428,7 @@ public:
         noexcept(std::is_nothrow_copy_constructible_v<E> && std::is_nothrow_convertible_v<G, E>)
 #endif
     {
-        static_assert(std::is_copy_constructible_v<E>, "E must be copy-constructible");
+        static_assert(std::is_move_constructible_v<E>, "E must be move-constructible");
         static_assert(std::is_convertible_v<G, E>, "is_convertible_v<G, E> must be true");
         if (this->m_has_val)
         {

--- a/tests/test_expected/CMakeLists.txt
+++ b/tests/test_expected/CMakeLists.txt
@@ -3,6 +3,7 @@ project(test_expected)
 set(SOURCES
     base_tests.cpp
     monadic_tests.cpp
+    noexcept_tests.cpp
     test_expected_main.cpp
 )
 

--- a/tests/test_expected/noexcept_tests.cpp
+++ b/tests/test_expected/noexcept_tests.cpp
@@ -1,0 +1,90 @@
+#include <catch2/catch_all.hpp>
+
+#include <zeus/expected.hpp>
+
+struct FromType
+{
+};
+
+enum class NoThrowConvertible
+{
+    Yes,
+    No,
+};
+
+template<NoThrowConvertible N>
+struct ToType;
+
+template<>
+struct ToType<NoThrowConvertible::Yes>
+{
+    ToType()              = default;
+    ToType(ToType const&) = default;
+    ToType(ToType&&)      = default;
+
+    ToType(FromType const&) noexcept {}
+};
+
+template<>
+struct ToType<NoThrowConvertible::No>
+{
+    ToType()              = default;
+    ToType(ToType const&) = default;
+    ToType(ToType&&)      = default;
+
+    ToType(FromType const&) noexcept(false) {}
+};
+
+TEST_CASE("value_or() noexcept", "[noexcept, value_or]")
+{
+    { // noexcept(true)
+        using T        = ToType<NoThrowConvertible::Yes>;
+        using E        = int;
+        using Expected = zeus::expected<T, E>;
+        Expected e;
+        CHECK(noexcept(e.value_or(FromType {})));
+    }
+    { // noexcept(false)
+        using T        = ToType<NoThrowConvertible::No>;
+        using E        = int;
+        using Expected = zeus::expected<T, E>;
+        Expected e;
+        CHECK_FALSE(noexcept(e.value_or(FromType {})));
+    }
+}
+
+TEST_CASE("error_or() noexcept", "[noexcept, error_or]")
+{
+    { // noexcept(true)
+        using T        = int;
+        using E        = ToType<NoThrowConvertible::Yes>;
+        using Expected = zeus::expected<T, E>;
+        Expected e;
+        CHECK(noexcept(e.error_or(FromType {})));
+    }
+    { // noexcept(false)
+        using T        = int;
+        using E        = ToType<NoThrowConvertible::No>;
+        using Expected = zeus::expected<T, E>;
+        Expected e;
+        CHECK_FALSE(noexcept(e.error_or(FromType {})));
+    }
+}
+
+TEST_CASE("void-T error_or() noexcept", "[noexcept, error_or, void-T]")
+{
+    { // noexcept(true)
+        using T        = void;
+        using E        = ToType<NoThrowConvertible::Yes>;
+        using Expected = zeus::expected<T, E>;
+        Expected e;
+        CHECK(noexcept(e.error_or(FromType {})));
+    }
+    { // noexcept(false)
+        using T        = void;
+        using E        = ToType<NoThrowConvertible::No>;
+        using Expected = zeus::expected<T, E>;
+        Expected e;
+        CHECK_FALSE(noexcept(e.error_or(FromType {})));
+    }
+}


### PR DESCRIPTION
This PR fix #2 and some constraints issues about `value_or()` / `error_or()`.